### PR TITLE
improve access modifier handling

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -489,6 +489,8 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   implicit object InvalidFinalAbstract extends InvalidModCombination(Mod.Final(), Mod.Abstract())
   implicit object InvalidFinalSealed extends InvalidModCombination(Mod.Final(), Mod.Sealed())
   implicit object InvalidOverrideAbstract extends InvalidModCombination(Mod.Override(), Mod.Abstract())
+  implicit object InvalidPrivateProtected extends InvalidModCombination(Mod.Private(Name.Anonymous()), Mod.Protected(Name.Anonymous()))
+  implicit object InvalidProtectedPrivate extends InvalidModCombination(Mod.Protected(Name.Anonymous()), Mod.Private(Name.Anonymous()))
 
 /* -------------- TOKEN CLASSES ------------------------------------------- */
 
@@ -2684,8 +2686,21 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   def modifiers(isLocal: Boolean = false): List[Mod] = {
     def appendMod(mods: List[Mod], mod: Mod): List[Mod] = {
       def validate() = {
-        if (isLocal && !mod.tokens.head.is[LocalModifier]) syntaxError("illegal modifier for a local definition", at = mod)
-        if (!mod.is[Mod.Quasi]) mods.foreach(m => if (m.productPrefix == mod.productPrefix) syntaxError("repeated modifier", at = mod))
+        if (isLocal && !mod.tokens.head.is[LocalModifier]) {
+          syntaxError("illegal modifier for a local definition", at = mod)
+        }
+        if (!mod.is[Mod.Quasi]) {
+          if (mods.exists(_.productPrefix == mod.productPrefix)) {
+            syntaxError("repeated modifier", at = mod)
+          }
+          if (mods.exists(_.isNakedAccessMod) && mod.isNakedAccessMod) {
+            if (mod.is[Mod.Protected]) rejectModCombination[Mod.Private, Mod.Protected](mods :+ mod, "")
+            if (mod.is[Mod.Private]) rejectModCombination[Mod.Protected, Mod.Private](mods :+ mod, "")
+          }
+          if (mods.exists(_.isQualifiedAccessMod) && mod.isQualifiedAccessMod) {
+            syntaxError("duplicate private/protected qualifier", at = mod)
+          }
+        }
       }
       validate()
       mods :+ mod

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -367,12 +367,34 @@ class ModSuite extends ParseSuite {
 
   test("invalid private and protected") {
     interceptParseErrors(
+      "private private class A",
+      "private private[foo] class A",
+      "private protected class A",
+      // "private protected[foo] class A", /* see the test below */
+      "private[foo] private class A",
+      "private[foo] private[foo] class A",
+      // "private[foo] protected class A", /* see the test below */
+      "private[foo] protected[foo] class A",
+      "protected private class A",
+      // "protected private[foo] class A", /* see the test below */
       "protected protected class A",
-      "private private class A"
+      "protected protected[foo] class A",
+      // "protected[foo] private class A", /* see the test below */
+      "protected[foo] private[foo] class A",
+      "protected[foo] protected class A",
+      "protected[foo] protected[foo] class A"
     )
   }
 
-  test("duplicate qualifiers") {
-    val Defn.Def(Seq(Mod.Private(Name.Indeterminate("foo")), Mod.Protected(Name.Anonymous())), Term.Name("bar"), Nil, Nil, None, Term.Name("???")) = templStat("private[foo] protected def bar = ???")
+  test("not really invalid private and protected") {
+    // NOTE: Surprisingly, the code below is valid Scala.
+    val Defn.Def(Seq(Mod.Private(Name.Anonymous()), Mod.Protected(Name.Indeterminate("foo"))), _, _, _, _, _) =
+      templStat("private protected[foo] def foo = ???")
+    val Defn.Def(Seq(Mod.Private(Name.Indeterminate("foo")), Mod.Protected(Name.Anonymous())), _, _, _, _, _) =
+      templStat("private[foo] protected def foo = ???")
+    val Defn.Def(Seq(Mod.Protected(Name.Anonymous()), Mod.Private(Name.Indeterminate("foo"))), _, _, _, _, _) =
+      templStat("protected private[foo] def foo = ???")
+    val Defn.Def(Seq(Mod.Protected(Name.Indeterminate("foo")), Mod.Private(Name.Anonymous())), _, _, _, _, _) =
+      templStat("protected[foo] private def foo = ???")
   }
 }


### PR DESCRIPTION
Builds on the work by @usrinivasan to make sure we correctly handle
all 16 combinations that arise from mixing `private`, `private[foo]`,
`protected` and `protected[foo]`.